### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 一个基于 arXiv 的论文检索与内容解析工具。支持 Model Context Protocol (MCP) 标准，提供论文搜索、PDF链接获取和内容解析功能。
 
+<a href="https://glama.ai/mcp/servers/@yzfly/Arxiv-Paper-MCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yzfly/Arxiv-Paper-MCP/badge" alt="ArXiv Paper MCP server" />
+</a>
+
 ## 功能特性
 
 * 🔍 **arXiv 论文智能搜索**：关键词检索，快速定位你关心的论文


### PR DESCRIPTION
This PR adds a badge for the [ArXiv Paper MCP](https://glama.ai/mcp/servers/@yzfly/Arxiv-Paper-MCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@yzfly/Arxiv-Paper-MCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yzfly/Arxiv-Paper-MCP/badge" alt="ArXiv Paper MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.